### PR TITLE
Disable autoballoon in xl.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+help:
+	@echo "Available targets:"
+	@echo " install - install files"
+
+install:
+	install -d $(DESTDIR)/etc/xen
+	echo "autoballoon=0" > $(DESTDIR)/etc/xen/xl.conf.qubes

--- a/debian/xen-utils-guest.displace
+++ b/debian/xen-utils-guest.displace
@@ -1,0 +1,1 @@
+/etc/xen/xl.conf


### PR DESCRIPTION
Automatic detection crashes in domU (see referenced issue). Since it
isn't relevant for driver domains, simply disable it.

Fixes QubesOS/qubes-issues#10050